### PR TITLE
Create library_generation.sh

### DIFF
--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -74,6 +74,6 @@ echo "" > /project/microros_static_library/libmicroros/built_packages
 for f in $(find $(pwd) -name .git -type d); do pushd $f > /dev/null; echo $(git config --get remote.origin.url) $(git rev-parse HEAD) >> /project/microros_static_library/libmicroros/built_packages; popd > /dev/null; done;
 
 ######## Fix permissions ########
-sudo chmod -R 777 /project/microros_static_library/libmicroros/libmicroros/ 
-sudo chmod -R 777 /project/microros_static_library/libmicroros/libmicroros/include/ 
-sudo chmod -R 777 /project/microros_static_library/libmicroros/libmicroros/libmicroros.a
+sudo chmod -R 777 /project/microros_static_library/libmicroros/ 
+sudo chmod -R 777 /project/microros_static_library/libmicroros/microros_include/ 
+sudo chmod -R 777 /project/microros_static_library/libmicroros/libmicroros.a


### PR DESCRIPTION
The relative path for the "Fix permission" section has been modified. There were additional nested directory (libmicroros directory) in the address which has been removed. Also the name of "include" directory has been changed to the "microros_include" according to the line 64.